### PR TITLE
Move away from UNSAFE lifecycle method

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "enzyme": "^3.0.0",
     "enzyme-adapter-react-16": "^1.0.0",
     "fixpack": "^2.3.1",
+    "prettier": "^1.13.5",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0",
@@ -47,7 +48,7 @@
   },
   "scripts": {
     "build": "babel src --out-dir lib",
-    "lint": "fixpack && standard --fix",
+    "lint": "fixpack && prettier src/**/*.js --write && standard --fix",
     "prepublishOnly": "npm run build",
     "test": "npm run lint && ava"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,51 +1,28 @@
-const {program} = require('raj/runtime')
+const { program } = require('raj/runtime')
 
-function reactProgram (Component, createApp) {
+exports.program = function reactProgram (Component, createApp) {
   return class RajProgram extends Component {
-    constructor (props) {
-      super(props)
-      this.makeProgram(props, true)
-    }
-
-    makeProgram (props, initial) {
-      this.killProgram()
-      const {view, ...app} = createApp(props)
-      this._view = view
+    componentDidMount () {
+      const app = createApp(this.props)
+      this._view = app.view
       this._killProgram = program({
         ...app,
         view: (state, dispatch) => {
           this._dispatch = dispatch
-          if (initial) {
-            this.state = {state}
-            initial = false
-          } else {
-            this.setState(() => ({state}))
-          }
+          this.setState(() => ({ state }))
         }
       })
     }
 
-    killProgram () {
+    componentWillUnmount () {
       if (this._killProgram) {
         this._killProgram()
         this._killProgram = undefined
       }
     }
 
-    componentWillReceiveProps (newProps) {
-      if (newProps !== this.props) {
-        this.makeProgram(newProps, false)
-      }
-    }
-
-    componentWillUnmount () {
-      this.killProgram()
-    }
-
     render () {
-      return this._view(this.state.state, this._dispatch)
+      return this._view ? this._view(this.state.state, this._dispatch) : null
     }
   }
 }
-
-module.exports = {program: reactProgram}


### PR DESCRIPTION
The `componentWillReceiveProps` method has been deprecated and will be removed in React v0.17. If the runtime needs to update via prop changes, it's recommended to provide a new `key`.